### PR TITLE
Fix syntactic completions not working

### DIFF
--- a/icedust/trans/_editor/services.str
+++ b/icedust/trans/_editor/services.str
@@ -18,7 +18,7 @@ imports // functions
   lib/string
   prettyprinting/pp
   names/naming/names
-  completion/IceDust-cp
+  completion/completion
   runtime/completion/-
   
 rules // Editor services

--- a/icedust/trans/prettyprinting/pp.str
+++ b/icedust/trans/prettyprinting/pp.str
@@ -24,17 +24,24 @@ rules
   
   pp-IceDust-string =
       parenthesize-IceDust
-    ; apply-pp-variation
+    ; try(apply-pp-variation)
     ; prettyprint-IceDust-Start
     ; !V([], <id>)
     ; box2text-string(|120)
 
   pp-partial-IceDust-string =
       parenthesize-IceDust
-    ; apply-pp-variation
+    ; try(apply-pp-variation)
     ; prettyprint-IceDust
     ; !V([], <id>)
     ; box2text-string(|120)
+    
+  pp-partial-IceDust-string(|sort) =
+      parenthesize-IceDust
+    ; try(apply-pp-variation)
+    ; prettyprint-IceDust(|sort)
+    ; !V([], <id>)
+    ; box2text-string(|120)  
        
   pp-debug :
     ast -> result

--- a/icedust/trans/prettyprinting/variations.str
+++ b/icedust/trans/prettyprinting/variations.str
@@ -44,7 +44,7 @@ rules // newline a derivation expression if subexpression is multiline + align c
   pp-variation: e -> e'
     where
       is-entity
-    with
+    where
       maxnamelength := <entity-get-members;filter(is-attr);map(attr-get-name);map(strlen);list-max(|0)>e;
       maxtypelenght := <entity-get-members;filter(is-attr);map(ttuple(attr-get-type,attr-get-mult);pp-type-and-multiplicity;strlen);list-max(|0)>e;
       e'            := <topdown(try(pp-variation(|maxnamelength, maxtypelenght)))>e
@@ -56,7 +56,7 @@ rules // newline a derivation expression if subexpression is multiline + align c
   pp-variation(|n,t): DefaultAttribute   (a, b, c, d, e) -> DefaultAttributePPMultiLine   (a, a', b, c, c', d, e) where <    multiline-expression >d with a' := <subt;whitespace>(n,<strlen>a) with c' := <subt;whitespace>(t,<pp-type-and-multiplicity;strlen>(b,c))
 
   pp-type-and-multiplicity: (ty, mu) -> $[[pp-ty][pp-mu]]
-    with
+    where
       pp-ty := <          prettyprint-IceDust-PrimitiveType ;!V([], <id>);box2text-string(|120)>ty;
       pp-mu := <pp-option(prettyprint-IceDust-Multiplicity );!V([], <id>);box2text-string(|120)>mu
 


### PR DESCRIPTION
Changed the completion import and added the required `pp-partial-IceDust-string(|sort)` strategy.
The `pp-varation` strategy was failing in a `with` clause, so I turned those into `where` clauses, and put a `try` around it.