### PR TITLE
added backend config for java dynamic semantics test cases

### DIFF
--- a/icedust.test/dynamic-semantics/java/features/abstractfield/abstractfield.spt
+++ b/icedust.test/dynamic-semantics/java/features/abstractfield/abstractfield.spt
@@ -5,6 +5,9 @@ language icedust
 fixture [[
 module abstractfield [[...]]
   
+config
+  backend: Java  
+
 model
 
   entity Submission {

--- a/icedust.test/dynamic-semantics/java/features/expressions/cast/cast.spt
+++ b/icedust.test/dynamic-semantics/java/features/expressions/cast/cast.spt
@@ -5,6 +5,9 @@ language icedust
 fixture [[
   module cast (on-demand)
   
+  config
+    backend: Java
+  
   execute
     concat(5.0 as String + " " + true as String + " " + 5 as String ++ no value as String)
     [[...]]

--- a/icedust.test/dynamic-semantics/java/features/expressions/datetime/datetime.spt
+++ b/icedust.test/dynamic-semantics/java/features/expressions/datetime/datetime.spt
@@ -5,6 +5,9 @@ language icedust
 fixture [[
   module datetime
 
+  config
+    backend: Java
+
   execute
     
     (2015-1-1 0:00:00 - 2014-12-31 0:00:00) /. 3600

--- a/icedust.test/dynamic-semantics/java/features/expressions/logic/logic.spt
+++ b/icedust.test/dynamic-semantics/java/features/expressions/logic/logic.spt
@@ -5,6 +5,9 @@ language icedust
 fixture [[
   module logic (on-demand)
   
+  config
+    backend: Java
+  
   model
   entity X {
     val : Int = (42 >= 4 && !false ? "a" : "b") == "a" ? 5 : 88 + 4

--- a/icedust.test/dynamic-semantics/java/features/expressions/math/math.spt
+++ b/icedust.test/dynamic-semantics/java/features/expressions/math/math.spt
@@ -5,6 +5,9 @@ language icedust
 fixture [[
   module math (on-demand)
   
+  config
+    backend: Java
+  
   model
   entity X {
     val : Int ? = 42 * 6 % 10 /. (5 - 10) + 4 - 3 * 8 /. -1 + (3 / 2) as Int

--- a/icedust.test/dynamic-semantics/java/features/expressions/multiplicities/multiplicities.spt
+++ b/icedust.test/dynamic-semantics/java/features/expressions/multiplicities/multiplicities.spt
@@ -5,6 +5,9 @@ language icedust
 fixture [[
   module multiplicities (on-demand)
   
+  config
+    backend: Java
+  
   model
   entity Foo{
     input1  : Int = 5

--- a/icedust.test/dynamic-semantics/java/features/expressions/nestedIf/nestedIf.spt
+++ b/icedust.test/dynamic-semantics/java/features/expressions/nestedIf/nestedIf.spt
@@ -5,6 +5,9 @@ language icedust
 fixture [[
   module nestedIf (on-demand)
   
+  config
+    backend: Java
+  
   model
   
     entity Z{

--- a/icedust.test/dynamic-semantics/java/features/expressions/references/references.spt
+++ b/icedust.test/dynamic-semantics/java/features/expressions/references/references.spt
@@ -5,6 +5,9 @@ language icedust
 fixture [[
   module references (on-demand)
   
+  config
+    backend: Java
+  
   model
   entity Foo{
     input1  : Int = 5

--- a/icedust.test/dynamic-semantics/java/features/inlinefield/inlinefield.spt
+++ b/icedust.test/dynamic-semantics/java/features/inlinefield/inlinefield.spt
@@ -4,7 +4,10 @@ language icedust
 
 fixture [[
 module inlinefield
-  
+
+config
+  backend: Java
+
 model
 
   entity Foo{

--- a/icedust.test/dynamic-semantics/java/features/ondemandincremental/ondemandincremental.spt
+++ b/icedust.test/dynamic-semantics/java/features/ondemandincremental/ondemandincremental.spt
@@ -4,7 +4,10 @@ language icedust
 
 fixture [[
 module ondemandincremental (on-demand incremental)
-  
+
+config
+  backend: Java
+
 model
 
   entity Foo{

--- a/icedust.test/dynamic-semantics/java/programs/incometax/incometax.spt
+++ b/icedust.test/dynamic-semantics/java/programs/incometax/incometax.spt
@@ -6,6 +6,9 @@ fixture [[
 
 module incometax [[...]]
 
+config
+  backend: Java
+
 model
   
   entity JobOffer{

--- a/icedust.test/dynamic-semantics/java/programs/weblab/weblab.spt
+++ b/icedust.test/dynamic-semantics/java/programs/weblab/weblab.spt
@@ -6,6 +6,9 @@ fixture [[
 
 module weblab (incremental)
 
+config
+  backend: Java
+
 //================================================================================
 
 model

--- a/icedust.test/dynamic-semantics/java/programs/weblab/weblab2.spt
+++ b/icedust.test/dynamic-semantics/java/programs/weblab/weblab2.spt
@@ -6,6 +6,9 @@ fixture [[
 
 module weblab2
 
+config
+  backend: Java
+
 // A simplified model of a grade calculation and course statistics tool in the university.
 //
 // It features:


### PR DESCRIPTION
Java test cases fail in the PixieDust fork, since the default backend there is the PixieDust backend. explicit backend configuration fixes this.